### PR TITLE
Allow voiding responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Setting ignore version to true on retries should only happen if the code is
 extremely resilient, hence we're very confident only temporary issues would
 cause it to fail.
 
-Setting the response queue to `void` will cause the reddit proxy to never
+Prefixing the response queue with `void` will cause the reddit proxy to never
 send a response. There will be no way to confirm the success of the request.
 
 ### Special Request Types

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ Setting ignore version to true on retries should only happen if the code is
 extremely resilient, hence we're very confident only temporary issues would
 cause it to fail.
 
+Setting the response queue to `void` will cause the reddit proxy to never
+send a response. There will be no way to confirm the success of the request.
+
 ### Special Request Types
 
 Request types prefixed with an underscore have no "style" argument as they only

--- a/src/handlers/manager.py
+++ b/src/handlers/manager.py
@@ -113,7 +113,8 @@ def listen_with_handlers(logger, amqp, handlers):
                 'New response queue {} detected at version {}',
                 body['response_queue'], body['version_utc_seconds']
             )
-            channel.queue_declare(body['response_queue'])
+            if not body['response_queue'].startswith('void'):
+                channel.queue_declare(body['response_queue'])
             resp_info = {'version': body['version_utc_seconds']}
             response_queues[body['response_queue']] = resp_info
         elif not body.get('ignore_version') and body['version_utc_seconds'] < resp_info['version']:
@@ -200,7 +201,7 @@ def listen_with_handlers(logger, amqp, handlers):
         )
         logger.connection.commit()
 
-        if body['response_queue'] == 'void':
+        if body['response_queue'].startswith('void'):
             channel.basic_ack(method_frame.delivery_tag)
         elif handle_style['operation'] == 'copy':
             channel.basic_publish('', body['response_queue'], json.dumps({

--- a/src/handlers/manager.py
+++ b/src/handlers/manager.py
@@ -200,7 +200,9 @@ def listen_with_handlers(logger, amqp, handlers):
         )
         logger.connection.commit()
 
-        if handle_style['operation'] == 'copy':
+        if body['response_queue'] == 'void':
+            channel.basic_ack(method_frame.delivery_tag)
+        elif handle_style['operation'] == 'copy':
             channel.basic_publish('', body['response_queue'], json.dumps({
                 'uuid': body['uuid'],
                 'type': 'copy',


### PR DESCRIPTION
Prefixing a response queue with void will cause messages not to actually be sent to the queue, which is useful considering the web backend isn't going to wait for confirmations most of the time